### PR TITLE
Dev/logging optimized

### DIFF
--- a/redengine/conditions/task.py
+++ b/redengine/conditions/task.py
@@ -134,7 +134,7 @@ class TaskTerminated(Historical, Comparable):
                 # else the old records must be fetched in case the task ran multiple times
                 return True
         elif allow_optimization and self.equal_zero():
-            return bool(task.last_terminate)
+            return not bool(task.last_terminate)
 
         records = task.logger.get_records(timestamp=(_start_, _end_), action="terminate")
         return [record["timestamp"] for record in records]

--- a/redengine/core/condition/statement.py
+++ b/redengine/core/condition/statement.py
@@ -209,6 +209,25 @@ class Comparable(Statement):
             for comp, val in comps.items()
         )
 
+    def any_over_zero(self):
+        # Useful for optimization: just find any observation and the statement is true
+        comps = {
+            comp: self.kwargs[comp]
+            for comp in self._comp_attrs
+            if comp in self.kwargs
+        }
+        if comps == {"_gt_": 0} or comps == {"_ge_": 1} or comps == {"_gt_": 0, "_ge_": 1}:
+            return True
+        return not comps
+
+    def equal_zero(self):
+        comps = {
+            comp: self.kwargs[comp]
+            for comp in self._comp_attrs
+            if comp in self.kwargs
+        }
+        return comps == {"_eq_": 0}
+
     def __eq__(self, other):
         # self == other
         is_same_class = isinstance(other, Comparable)

--- a/redengine/core/task.py
+++ b/redengine/core/task.py
@@ -180,6 +180,8 @@ class Task(metaclass=_TaskMeta):
     last_run: Optional[datetime.datetime]
     last_success: Optional[datetime.datetime]
     last_fail: Optional[datetime.datetime]
+    last_terminate: Optional[datetime.datetime]
+    last_inaction: Optional[datetime.datetime]
 
     # Class defaults
     default_priority = 0
@@ -244,6 +246,7 @@ class Task(metaclass=_TaskMeta):
         self._last_success = self._get_last_action_from_log("success")
         self._last_fail = self._get_last_action_from_log("fail")
         self._last_terminate = self._get_last_action_from_log("terminate")
+        self._last_inaction = self._get_last_action_from_log("inaction")
 
         self.register()
         
@@ -943,8 +946,13 @@ class Task(metaclass=_TaskMeta):
 
     @property
     def last_terminate(self):
-        """datetime.datetime: The lastest timestamp when the task ran."""
+        """datetime.datetime: The lastest timestamp when the task terminated."""
         return self._get_last_action("terminate")
+
+    @property
+    def last_inaction(self):
+        """datetime.datetime: The lastest timestamp when the task inacted."""
+        return self._get_last_action("inaction")
 
     def _get_last_action(self, action):
         cache_attr = f"_last_{action}"

--- a/redengine/test/condition/task/test_time_executable.py
+++ b/redengine/test/condition/task/test_time_executable.py
@@ -173,7 +173,7 @@ from redengine.tasks import FuncTask
     ],
 )
 def test_executable(tmpdir, mock_datetime_now, logs, time_after, get_condition, outcome, session):
-
+    session.config["force_status_from_logs"] = True
     def to_epoch(dt):
         # Hack as time.tzlocal() does not work for 1970-01-01
         if dt.tz:

--- a/redengine/test/condition/task/test_time_optimized.py
+++ b/redengine/test/condition/task/test_time_optimized.py
@@ -15,7 +15,7 @@ from redengine.conditions import (
 
     TaskRunning
 )
-from redengine.conditions.task import TaskInacted
+from redengine.conditions.task import TaskInacted, TaskTerminated
 from redengine.time import (
     TimeDelta, 
     TimeOfDay
@@ -32,7 +32,7 @@ def to_epoch(dt):
 
 @pytest.mark.parametrize("cls",
     [
-        TaskFailed, TaskSucceeded, TaskFinished, TaskRunning, TaskStarted, TaskInacted
+        TaskFailed, TaskSucceeded, TaskFinished, TaskRunning, TaskStarted, TaskInacted, TaskTerminated
     ]
 )
 def test_logs_not_used_false(session, cls, mock_datetime_now):
@@ -53,7 +53,7 @@ def test_logs_not_used_false(session, cls, mock_datetime_now):
 
 @pytest.mark.parametrize("cls",
     [
-        TaskFailed, TaskSucceeded, TaskFinished, TaskRunning, TaskStarted, TaskInacted
+        TaskFailed, TaskSucceeded, TaskFinished, TaskRunning, TaskStarted, TaskInacted, TaskTerminated
     ]
 )
 def test_logs_not_used_true(session, cls, mock_datetime_now):
@@ -71,7 +71,7 @@ def test_logs_not_used_true(session, cls, mock_datetime_now):
 
 @pytest.mark.parametrize("cls",
     [
-        TaskFailed, TaskSucceeded, TaskFinished, TaskRunning, TaskStarted, TaskInacted
+        TaskFailed, TaskSucceeded, TaskFinished, TaskRunning, TaskStarted, TaskInacted, TaskTerminated
     ]
 )
 def test_logs_not_used_true_inside_period(session, cls, mock_datetime_now):
@@ -90,7 +90,7 @@ def test_logs_not_used_true_inside_period(session, cls, mock_datetime_now):
 
 @pytest.mark.parametrize("cls",
     [
-        TaskFailed, TaskSucceeded, TaskFinished, TaskStarted, TaskInacted
+        TaskFailed, TaskSucceeded, TaskFinished, TaskStarted, TaskInacted, TaskTerminated
     ]
 )
 def test_logs_not_used_false_outside_period(session, cls, mock_datetime_now):
@@ -109,7 +109,7 @@ def test_logs_not_used_false_outside_period(session, cls, mock_datetime_now):
 
 @pytest.mark.parametrize("cls",
     [
-        TaskFailed, TaskSucceeded, TaskFinished, TaskStarted, TaskInacted
+        TaskFailed, TaskSucceeded, TaskFinished, TaskStarted, TaskInacted, TaskTerminated
     ]
 )
 def test_logs_not_used_equal_zero(session, cls, mock_datetime_now):
@@ -130,7 +130,7 @@ def test_logs_not_used_equal_zero(session, cls, mock_datetime_now):
 
 @pytest.mark.parametrize("cls",
     [
-        TaskFailed, TaskSucceeded, TaskFinished, TaskStarted, TaskInacted
+        TaskFailed, TaskSucceeded, TaskFinished, TaskStarted, TaskInacted, TaskTerminated
     ]
 )
 def test_logs_used(session, cls, mock_datetime_now):

--- a/redengine/test/condition/task/test_time_optimized.py
+++ b/redengine/test/condition/task/test_time_optimized.py
@@ -1,0 +1,157 @@
+
+import logging
+from typing import List, Tuple
+
+import pytest
+import pandas as pd
+from dateutil.tz import tzlocal
+
+from redengine.conditions import (
+    TaskStarted, 
+
+    TaskFinished, 
+    TaskFailed, 
+    TaskSucceeded,
+
+    TaskRunning
+)
+from redengine.conditions.task import TaskInacted
+from redengine.time import (
+    TimeDelta, 
+    TimeOfDay
+)
+from redengine.tasks import FuncTask
+
+from .test_time import setup_task_state
+
+def to_epoch(dt):
+    # Hack as time.tzlocal() does not work for 1970-01-01
+    if dt.tz:
+        dt = dt.tz_convert("utc").tz_localize(None)
+    return (dt - pd.Timestamp("1970-01-01")) // pd.Timedelta('1s')
+
+@pytest.mark.parametrize("cls",
+    [
+        TaskFailed, TaskSucceeded, TaskFinished, TaskRunning, TaskStarted, TaskInacted
+    ]
+)
+def test_logs_not_used_false(session, cls, mock_datetime_now):
+    session.config["force_read_from_logs"] = False
+    
+    task = FuncTask(
+        lambda:None, 
+        name="the task",
+        execution="main"
+    )
+    logs = [
+        ("2021-01-01 12:00:00", state)
+        for state in ("success", "fail", "run", "terminate", "inaction")
+    ]
+    setup_task_state(mock_datetime_now, logs, task=task)
+    cond = cls(task=task)
+    assert not cond
+
+@pytest.mark.parametrize("cls",
+    [
+        TaskFailed, TaskSucceeded, TaskFinished, TaskRunning, TaskStarted, TaskInacted
+    ]
+)
+def test_logs_not_used_true(session, cls, mock_datetime_now):
+    session.config["force_read_from_logs"] = False
+    
+    task = FuncTask(
+        lambda:None, 
+        name="the task",
+        execution="main"
+    )
+    for attr in ("_last_run", "_last_success", "_last_fail", "_last_inaction", "_last_terminate"):
+        setattr(task, attr, pd.Timestamp("2000-01-01 12:00:00"))
+    cond = cls(task=task)
+    assert cond
+
+@pytest.mark.parametrize("cls",
+    [
+        TaskFailed, TaskSucceeded, TaskFinished, TaskRunning, TaskStarted, TaskInacted
+    ]
+)
+def test_logs_not_used_true_inside_period(session, cls, mock_datetime_now):
+    session.config["force_read_from_logs"] = False
+    
+    task = FuncTask(
+        lambda:None, 
+        name="the task",
+        execution="main"
+    )
+    for attr in ("_last_run", "_last_success", "_last_fail", "_last_inaction", "_last_terminate"):
+        setattr(task, attr, pd.Timestamp("2000-01-01 12:00:00"))
+    cond = cls(task=task, period=TimeOfDay("07:00", "13:00"))
+    mock_datetime_now("2000-01-01 14:00")
+    assert bool(cond)
+
+@pytest.mark.parametrize("cls",
+    [
+        TaskFailed, TaskSucceeded, TaskFinished, TaskStarted, TaskInacted
+    ]
+)
+def test_logs_not_used_false_outside_period(session, cls, mock_datetime_now):
+    session.config["force_read_from_logs"] = False
+    
+    task = FuncTask(
+        lambda:None, 
+        name="the task",
+        execution="main"
+    )
+    for attr in ("_last_run", "_last_success", "_last_fail", "_last_inaction", "_last_terminate"):
+        setattr(task, attr, pd.Timestamp("2000-01-01 05:00:00"))
+    cond = cls(task=task, period=TimeOfDay("07:00", "13:00"))
+    mock_datetime_now("2000-01-01 14:00")
+    assert not cond
+
+@pytest.mark.parametrize("cls",
+    [
+        TaskFailed, TaskSucceeded, TaskFinished, TaskStarted, TaskInacted
+    ]
+)
+def test_logs_not_used_equal_zero(session, cls, mock_datetime_now):
+    session.config["force_read_from_logs"] = False
+    
+    task = FuncTask(
+        lambda:None, 
+        name="the task",
+        execution="main"
+    )
+    logs = [
+        ("2021-01-01 12:00:00", state)
+        for state in ("success", "fail", "run", "terminate", "inaction")
+    ]
+    setup_task_state(mock_datetime_now, logs, task=task)
+    cond = cls(task=task) == 0
+    assert cond
+
+@pytest.mark.parametrize("cls",
+    [
+        TaskFailed, TaskSucceeded, TaskFinished, TaskStarted, TaskInacted
+    ]
+)
+def test_logs_used(session, cls, mock_datetime_now):
+    session.config["force_read_from_logs"] = False
+    
+    task = FuncTask(
+        lambda:None, 
+        name="the task",
+        execution="main"
+    )
+    logs = [
+        ("2021-01-01 12:00:00", state)
+        for state in ("success", "fail", "run", "terminate", "inaction")
+    ]
+    setup_task_state(mock_datetime_now, logs, task=task)
+    # Only the latest status is stored
+    # thus one cannot determine whether the task has run percisely once
+    # without looking to logs.
+    mock_datetime_now("2021-01-01 14:00")
+    if cls is TaskFinished:
+        cond = cls(task=task) == 3
+    else:
+        cond = cls(task=task) == 1 
+    assert cond


### PR DESCRIPTION
Uses now the task.last_{action} attribute for defining the state of several conditions to reduce IO. Can be disabled using sessionconfigs.