### PR TITLE
Dev/streamline parsers

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,8 @@ include redengine/test/test_files/*.ipynb
 include redengine/test/test_files/*.py
 include redengine/config/defaults/*.yaml
 include versioneer.py
+include redengine/_session.py
+include redengine/_setup.py
+include redengine/_pkg.py
 include redengine/_version.py
 recursive-include redengine/templates *

--- a/redengine/__init__.py
+++ b/redengine/__init__.py
@@ -1,7 +1,7 @@
 
-
-from .core import Scheduler
 from ._session import Session
+from .core import Scheduler
+
 from ._setup import _setup_defaults
 from .config import *
 from . import (
@@ -13,9 +13,10 @@ from . import (
     tasks,
 )
 from .tasks import FuncTask
-_setup_defaults()
-
 session = Session()
 session.set_as_default()
+_setup_defaults()
+
+
 from . import _version
 __version__ = _version.get_versions()['version']

--- a/redengine/_base.py
+++ b/redengine/_base.py
@@ -1,0 +1,5 @@
+
+
+class RedBase:
+    """Baseclass for all Red Engine classes"""
+    session = None

--- a/redengine/_setup.py
+++ b/redengine/_setup.py
@@ -1,6 +1,8 @@
 from redengine.core import BaseCondition, Task
 
+from redengine._session import Session
 from redengine.parse import add_condition_parser
+from redengine.parse.session import session_parser
 from redengine.conditions import true, false
 
 def _setup_defaults():
@@ -19,3 +21,8 @@ def _setup_defaults():
         "always false": false,
         "always true": true
     })
+
+    Session.parser = session_parser
+
+    # Manually setting extra parsers
+    Session.parser["sequences"] = Session._ext_parsers["sequences"]

--- a/redengine/conditions/func.py
+++ b/redengine/conditions/func.py
@@ -2,8 +2,9 @@
 import copy
 from typing import Callable, List, Optional, Pattern, Union
 
+
+from redengine._session import Session
 from redengine.core.condition import BaseCondition
-from redengine.core.condition.base import PARSERS
 
 class FuncCond(BaseCondition):
     """Condition from a function.
@@ -89,9 +90,12 @@ class FuncCond(BaseCondition):
         return self.func(*self.args, **self.kwargs)
 
     def _set_parsing(self):
+
+        session = Session.session
+
         syntaxes = [self.syntax] if not isinstance(self.syntax, (list, tuple, set)) else self.syntax
         for syntax in syntaxes:
-            PARSERS[syntax] = self._recreate
+            session.cond_parsers[syntax] = self._recreate
 
     def __repr__(self):
         cls_name = type(self).__name__

--- a/redengine/conditions/meta.py
+++ b/redengine/conditions/meta.py
@@ -5,8 +5,6 @@ from typing import Callable, Pattern, Union
 from redengine.core.condition import BaseCondition #, Task
 from redengine.core.parameters.arguments import BaseArgument
 
-from redengine.core.condition.base import PARSERS
-
 class _CondStatus(BaseArgument):
 
     @classmethod
@@ -128,7 +126,7 @@ class TaskCond(BaseCondition):
 
     def _set_parsing(self):
         from redengine.parse import CondParser
-        PARSERS[self.syntax] = CondParser(func=self._set_task, cached=True)
+        self.session.cond_parsers[self.syntax] = CondParser(func=self._set_task, cached=True)
 
     def _get_func_name(self, func):
         func_module = func.__module__

--- a/redengine/core/condition/__init__.py
+++ b/redengine/core/condition/__init__.py
@@ -1,3 +1,3 @@
 from .statement import Statement, Historical, Comparable
 from .utils import set_defaults, set_statement_defaults
-from .base import AlwaysTrue, AlwaysFalse, All, Any, Not, BaseCondition, PARSERS, CLS_CONDITIONS
+from .base import AlwaysTrue, AlwaysFalse, All, Any, Not, BaseCondition, CLS_CONDITIONS

--- a/redengine/core/condition/base.py
+++ b/redengine/core/condition/base.py
@@ -2,7 +2,9 @@ import datetime
 from abc import abstractmethod
 from typing import Callable, Dict, Pattern, Union, Type
 
+from redengine._base import RedBase
 from redengine.core.meta import _add_parser, _register
+from redengine._session import Session
 
 
 CLS_CONDITIONS: Dict[str, Type['BaseCondition']] = {}
@@ -19,11 +21,18 @@ class _ConditionMeta(type):
         _register(cls, CLS_CONDITIONS)
 
         # Add the parsers
-        _add_parser(cls, container=PARSERS)
+        if cls.session is None:
+            # Red engine default conditions
+            # storing to the class
+            _add_parser(cls, container=Session._cond_parsers)
+        else:
+            # User defined conditions
+            # storing to the object
+            _add_parser(cls, container=cls.session.cond_parsers)
         return cls
 
 
-class BaseCondition(metaclass=_ConditionMeta):
+class BaseCondition(RedBase, metaclass=_ConditionMeta):
     """A condition is a thing/occurence that should happen in 
     order to something happen.
 
@@ -75,7 +84,7 @@ class BaseCondition(metaclass=_ConditionMeta):
 
     """
     # The session (set in redengine.session)
-    session = None
+    session: Session
 
     __parsers__ = {}
     __register__ = False

--- a/redengine/core/extensions.py
+++ b/redengine/core/extensions.py
@@ -1,6 +1,8 @@
 
 from redengine.parse.utils import instances, ParserPicker
 from redengine.core.meta import _register
+from redengine._session import Session
+from redengine._base import RedBase
 
 CLS_EXTENSIONS = {}
 PARSERS = {}
@@ -23,12 +25,14 @@ class _ExtensionMeta(type):
         if parse_key is not None:
             from redengine import Session
             parser = _get_parser(cls.parse_cls)
-            Session.parser[parse_key] = parser
-            PARSERS[parse_key] = parser
+            if Session.parser is not None:
+                # User defined
+                Session.parser[parse_key] = parser
+            Session._ext_parsers[parse_key] = parser
         _register(cls, CLS_EXTENSIONS)
         return cls
 
-class BaseExtension(metaclass=_ExtensionMeta):
+class BaseExtension(RedBase, metaclass=_ExtensionMeta):
     """Base for all extensions that are registered
     to the sessions and are parsable in configs.
 

--- a/redengine/core/parameters/arguments.py
+++ b/redengine/core/parameters/arguments.py
@@ -2,10 +2,12 @@
 from typing import Any, TYPE_CHECKING
 from abc import abstractmethod
 
+from redengine._base import RedBase
+
 if TYPE_CHECKING:
     import redengine
 
-class BaseArgument:
+class BaseArgument(RedBase):
     """Base class for Arguments.
     
     Argument is a wrapper for value that can be 

--- a/redengine/core/parameters/parameters.py
+++ b/redengine/core/parameters/parameters.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import Callable, Type, Union, TYPE_CHECKING
 from functools import partial
 
+from redengine._base import RedBase
 from .arguments import BaseArgument
 from redengine.core.utils import is_pickleable
 from redengine.pybox.io import read_yaml
@@ -12,7 +13,7 @@ from redengine.core.utils import filter_keyword_args
 if TYPE_CHECKING:
     import redengine
 
-class Parameters(Mapping): # Mapping so that mytask(**Parameters(...)) would work
+class Parameters(RedBase, Mapping): # Mapping so that mytask(**Parameters(...)) would work
     """Parameter set for tasks.
 
     Parameter set is a mapping (like dictionary).

--- a/redengine/core/schedule.py
+++ b/redengine/core/schedule.py
@@ -1,7 +1,7 @@
 
 from multiprocessing import cpu_count
 import multiprocessing
-from typing import Callable, Optional, Union
+from typing import TYPE_CHECKING, Callable, Optional, Union
 import threading
 import traceback
 import time
@@ -15,6 +15,7 @@ from queue import Empty
 import pandas as pd
 from redengine.arguments.builtin import Return
 
+from redengine._base import RedBase
 from redengine.core.condition import BaseCondition, set_statement_defaults, AlwaysFalse
 from redengine.core.task import Task
 from redengine.core.parameters import Parameters
@@ -22,8 +23,9 @@ from redengine.core.exceptions import SchedulerRestart, SchedulerExit
 from redengine.core.utils import is_pickleable
 from redengine.core.hook import _Hooker
 
-
-class Scheduler:
+if TYPE_CHECKING:
+    from redengine import Session
+class Scheduler(RedBase):
     """Multiprocessing scheduler
 
     Parameters
@@ -71,7 +73,7 @@ class Scheduler:
         for. One session has only one 
         scheduler.
     """
-    session = None # This is set as redengine.session
+    session: 'Session'
 
     def __init__(self, session=None, max_processes:Optional[int]=None, tasks_as_daemon:bool=True, timeout="30 minutes",
                 shut_cond:Optional[BaseCondition]=None, parameters:Optional[Parameters]=None,

--- a/redengine/core/task.py
+++ b/redengine/core/task.py
@@ -18,6 +18,7 @@ from queue import Empty
 import pandas as pd
 from redengine.arguments.builtin import Return
 
+from redengine._base import RedBase
 from redengine.core.condition import BaseCondition, AlwaysTrue, AlwaysFalse, All, set_statement_defaults
 from redengine.core.parameters import Parameters
 from redengine.core.log import TaskAdapter
@@ -46,7 +47,7 @@ class _TaskMeta(type):
         return cls
 
 
-class Task(metaclass=_TaskMeta):
+class Task(RedBase, metaclass=_TaskMeta):
     """Base class for Tasks.
 
     A task can be a function, command or other procedure that 
@@ -162,7 +163,7 @@ class Task(metaclass=_TaskMeta):
 
     daemon: Optional[bool]
 
-    session: 'Session' = None
+    session: 'Session'
     return_arg: Type['BaseArgument'] = Return
 
     # Instance

--- a/redengine/core/time/base.py
+++ b/redengine/core/time/base.py
@@ -6,8 +6,9 @@ import itertools
 
 import pandas as pd
 
+from redengine._base import RedBase
 from redengine.core.meta import _add_parser
-
+from redengine._session import Session
 
 PARSERS: Dict[Union[str, Pattern], Union[Callable, 'TimePeriod']] = {}
 
@@ -15,11 +16,16 @@ class _TimeMeta(type):
     def __new__(mcs, name, bases, class_dict):
         cls = type.__new__(mcs, name, bases, class_dict)
         # Add the parsers
-        _add_parser(cls, container=PARSERS)
+        if cls.session is None:
+            # Package defaults
+            _add_parser(cls, container=Session._time_parsers)
+        else:
+            # User defined
+            _add_parser(cls, container=cls.session.time_parsers)
         return cls
 
 
-class TimePeriod(metaclass=_TimeMeta):
+class TimePeriod(RedBase, metaclass=_TimeMeta):
     """Base for all classes that represent a time period.
 
     Time period is a period in time with a start and an end.

--- a/redengine/extensions/__init__.py
+++ b/redengine/extensions/__init__.py
@@ -1,4 +1,3 @@
 
 from .piping import Sequence
 from redengine.core import BaseExtension
-from redengine.core.extensions import PARSERS

--- a/redengine/parse/_condition/condition_item.py
+++ b/redengine/parse/_condition/condition_item.py
@@ -3,6 +3,7 @@ from typing import Callable, Dict, Pattern, Union
 
 from ..utils import ParserError, CondParser
 from redengine.core.condition.base import PARSERS, BaseCondition
+from redengine._session import Session
 
 CONDITION_PARSERS = []
 
@@ -15,12 +16,15 @@ def add_condition_parser(d: Dict[Union[str, Pattern], Union[Callable, 'BaseCondi
     d : dict
         TODO
     """
-    PARSERS.update(d)
+    parsers = Session._cond_parsers #! TODO
+    parsers.update(d)
 
 def parse_condition_item(s:str) -> BaseCondition:
     "Parse one condition"
 
-    for statement, parser in PARSERS.items():
+    session = Session.session
+
+    for statement, parser in session.cond_parsers.items():
         if isinstance(statement, Pattern):
             res = statement.fullmatch(s)
             if res:

--- a/redengine/parse/_time/time_item.py
+++ b/redengine/parse/_time/time_item.py
@@ -3,6 +3,7 @@ from typing import Pattern
 
 from ..utils import ParserError
 from redengine.core.time.base import PARSERS, TimePeriod
+from redengine._session import Session
 
 def add_time_parser(d):
     """Add a parsing instruction to be used for parsing a 
@@ -20,11 +21,12 @@ def add_time_parser(d):
         Whether the 's' is a regex or exact string, 
         by default True
     """
-    PARSERS.update(d)
+    Session._time_parsers.update(d)
 
 def parse_time_item(s:str):
     "Parse one condition"
-    for statement, parser in PARSERS.items():
+    parsers = Session.session.time_parsers
+    for statement, parser in parsers.items():
         if isinstance(statement, Pattern):
             res = statement.fullmatch(s)
             if res:

--- a/redengine/parse/session.py
+++ b/redengine/parse/session.py
@@ -1,0 +1,13 @@
+
+from . import StaticParser, Field
+from . import parse_logging, parse_scheduler, parse_tasks, parse_session_params
+
+session_parser = StaticParser({
+        "logging": Field(parse_logging, if_missing="ignore"),
+        "parameters": Field(parse_session_params, if_missing="ignore", types=(dict,)),
+        "tasks": Field(parse_tasks, if_missing="ignore", types=(dict, list)),
+        "scheduler": Field(parse_scheduler, if_missing="ignore"),
+        # Note that extensions are set in redengine.ext
+    },
+    on_extra="ignore", 
+)

--- a/redengine/parse/utils/cond.py
+++ b/redengine/parse/utils/cond.py
@@ -1,5 +1,4 @@
 
-from redengine.core.condition import BaseCondition
 
 class CondParser:
     "Utility class for parsing a condition item"
@@ -9,6 +8,7 @@ class CondParser:
         self.cached = cached
     
     def __call__(self, s:str, *args, **kwargs):
+        from redengine.core.condition import BaseCondition
         session = BaseCondition.session
         if self.cached and s in session.cond_cache:
             return session.cond_cache[s]

--- a/redengine/tasks/loaders.py
+++ b/redengine/tasks/loaders.py
@@ -365,7 +365,7 @@ class ExtensionLoader(ContentLoader):
             raise TypeError("Expected a list of tasks or a dict of task.")
 
     def parse_extensions(self, conf:dict):
-        for key, parser in extensions.PARSERS.items():
+        for key, parser in Session.session.ext_parsers.items():
             if key in conf:
                 ext_conf = conf[key]
                 if self.name_pattern:

--- a/redengine/test/session/test_construct.py
+++ b/redengine/test/session/test_construct.py
@@ -87,6 +87,20 @@ class TestInit:
         assert seqs["my-sequence-1"].interval == parse_time("every 2 hours")
         assert seqs["my-sequence-2"].interval is None
 
+    def test_set_cls_condition(self):
+        session = Session()
+        class MyCond(BaseCondition):
+            __parsers__ = {"is my foo": "__init__"}
+            def __bool__(self):
+                return True
+        
+        assert "is my foo" in session.cond_parsers
+        # Create new, should reset
+        session = Session()
+        assert "is my foo" not in session.cond_parsers
+        assert len(session.cond_parsers) > 0
+
+
 class TestDict:
 
     def test_empty(self):

--- a/redengine/time/__init__.py
+++ b/redengine/time/__init__.py
@@ -7,8 +7,9 @@ import calendar
 
 from .construct import get_between, get_before, get_after, get_full_cycle, get_on
 
-from redengine.core.time import PARSERS
-PARSERS.update(
+from redengine._session import Session
+
+Session._time_parsers.update(
     {
         re.compile(r"time of (?P<type_>month|week|day|hour|minute) between (?P<start>.+) and (?P<end>.+)"): get_between,
         re.compile(r"time of (?P<type_>month|week|day|hour|minute) after (?P<start>.+)"): get_after,


### PR DESCRIPTION
Notable changes:

- New base class ``redengine._base.RedBase`` for everything needing session as an attribute
- Removed ``redengine.core.time.PARSERS`` and ``redengine.core.condition.PARSERS``
- Add parsers to the session
  - User defined are set to:
    - ``session.cond_parsers``
    - ``session.time_parsers``
    - ``session.ext_parsers``
  - Built-in/package's parsers are set to
    - ``Session._cond_parsers``
    - ``Session._time_parsers``
    - ``Session._ext_parsers``