### PR TITLE
Compact after task

### DIFF
--- a/docs/condition_syntax/dependence.rst
+++ b/docs/condition_syntax/dependence.rst
@@ -10,6 +10,9 @@ Task Dependence
 
    after task '<task>'
    after task '<task>' [succeeded | failed | finished | terminated]
+   after tasks '<task 1>', '<task 2>' ... 
+   after tasks '<task 1>', '<task 2>' ... [succeeded | failed | finished]
+   after any tasks '<task 1>', '<task 2>' ... [succeeded | failed | finished]
 
 **True when**
 
@@ -34,3 +37,4 @@ Task Dependence
     FuncTask(..., start_cond="after task 'a task' succeeded")
     FuncTask(..., start_cond="after task 'a task' failed")
     FuncTask(..., start_cond="after task 'a task' finished")
+    FuncTask(..., start_cond="after tasks 'a task', 'another task' finished")

--- a/docs/tutorial/pipeline_guide.rst
+++ b/docs/tutorial/pipeline_guide.rst
@@ -88,8 +88,24 @@ task a or task b have succeeded* and so on:
 
 .. note::
 
-    In case the condition gets too long, you can split it to multiple lines.
-    For example:
+    If you have many dependent tasks, you can use a more compact version 
+    of the condition syntax for pipelining tasks with **all**:
+
+    .. code-block:: python
+
+        @FuncTask(start_cond="after tasks 'task_a', 'task_b', 'task_c' succeeded")
+        def my_task():
+            ...
+
+    There is also a compact version for **any** prerequisites:
+
+    .. code-block:: python
+
+        @FuncTask(start_cond="after any tasks 'task_a', 'task_b', 'task_c' succeeded")
+        def my_task():
+            ...
+
+    Alternatively, you can split them to multiple lines:
 
     .. code-block:: python
 

--- a/redengine/conditions/task/__init__.py
+++ b/redengine/conditions/task/__init__.py
@@ -1,0 +1,1 @@
+from .task import *

--- a/redengine/conditions/task/utils.py
+++ b/redengine/conditions/task/utils.py
@@ -1,0 +1,45 @@
+
+from redengine.core.condition import All, Any
+
+class DependMixin:
+
+    _dep_actions = None
+
+    def __init__(self, depend_task, task=None, **kwargs):
+        super().__init__(task=task, depend_task=depend_task, **kwargs)
+
+    @classmethod
+    def _parse_multi_all(cls, depend_tasks:str, task=None):
+        from redengine.parse import ParserError
+        tasks = depend_tasks.split("', '")
+        if not tasks:
+            raise ParserError
+        return All(*(cls(depend_task=dep_task, task=task) for dep_task in tasks))
+
+    @classmethod
+    def _parse_multi_any(cls, depend_tasks:str, task=None):
+        from redengine.parse import ParserError
+        tasks = depend_tasks.split("', '")
+        if not tasks:
+            raise ParserError
+        return Any(*(cls(depend_task=dep_task, task=task) for dep_task in tasks))
+
+    def observe(self, task, depend_task, **kwargs):
+        """True when the "depend_task" has succeeded and "task" has not yet ran after it.
+        Useful for start cond for task that should be run after success of another task.
+        """
+        actual_task = self.session.get_task(task)
+        depend_task = self.session.get_task(depend_task)
+
+        #! TODO: use Task._last_success & Task._last_run if not none and not forced
+        last_depend_finish = depend_task.logger.get_latest(action=self._dep_actions)
+        last_actual_start = actual_task.logger.get_latest(action=["run"])
+
+        if not last_depend_finish:
+            # Depend has not run at all
+            return False
+        elif not last_actual_start:
+            # Depend has succeeded but the actual task has not
+            return True
+            
+        return last_depend_finish["timestamp"] > last_actual_start["timestamp"]

--- a/redengine/parse/__init__.py
+++ b/redengine/parse/__init__.py
@@ -7,5 +7,5 @@ from .parameters import parse_session_params
 
 from ._condition import add_condition_parser
 
-from .utils import StaticParser, Field, CondParser
+from .utils import StaticParser, Field, CondParser, ParserError
 from .misc import parse_logging

--- a/redengine/test/condition/test_parse.py
+++ b/redengine/test/condition/test_parse.py
@@ -88,10 +88,21 @@ cases_task = [
 
     # Task dependent related (requires 2 tasks)
     pytest.param("after task 'other'",           DependSuccess(depend_task="other"), id="after task"),
-    pytest.param("after task 'other' succeeded", DependSuccess(depend_task="other"), id="after task successs"),
+    pytest.param("after task 'other' succeeded", DependSuccess(depend_task="other"), id="after task success"),
     pytest.param("after task 'other' failed",    DependFailure(depend_task="other"), id="after failed"),
     pytest.param("after task 'other' finished",  DependFinish(depend_task="other"), id="after finished"),
     pytest.param("after task 'group1.group-2.mytask+'", DependSuccess(depend_task="group1.group-2.mytask+"), id="after task special chars"),
+
+    # Multi
+    pytest.param("after tasks 'first', 'second', 'third'", All(DependSuccess(depend_task="first"), DependSuccess(depend_task="second"), DependSuccess(depend_task="third")), id="after task (multi)"),
+    pytest.param("after tasks 'first', 'second', 'third' succeeded", All(DependSuccess(depend_task="first"), DependSuccess(depend_task="second"), DependSuccess(depend_task="third")), id="after task success (multi)"),
+    pytest.param("after tasks 'first', 'second', 'third' failed", All(DependFailure(depend_task="first"), DependFailure(depend_task="second"), DependFailure(depend_task="third")), id="after task fail (multi)"),
+    pytest.param("after tasks 'first', 'second', 'third' finished", All(DependFinish(depend_task="first"), DependFinish(depend_task="second"), DependFinish(depend_task="third")), id="after task fail (multi)"),
+
+    pytest.param("after any tasks 'first', 'second', 'third' succeeded", Any(DependSuccess(depend_task="first"), DependSuccess(depend_task="second"), DependSuccess(depend_task="third")), id="after task success (multi)"),
+    pytest.param("after any tasks 'first', 'second', 'third' failed", Any(DependFailure(depend_task="first"), DependFailure(depend_task="second"), DependFailure(depend_task="third")), id="after task fail (multi)"),
+    pytest.param("after any tasks 'first', 'second', 'third' finished", Any(DependFinish(depend_task="first"), DependFinish(depend_task="second"), DependFinish(depend_task="third")), id="after task fail (multi)"),
+
 
     pytest.param("has failed today", TaskFailed(period=TimeOfDay()), id="has failed today"),
 ]
@@ -182,6 +193,8 @@ def test_back_to_string(cond_str, expected):
         pytest.param("true |", IndexError, id="OR, missing right"),
         pytest.param("& true", IndexError, id="AND, missing left"),
         pytest.param("| true", IndexError, id="OR, missing left"),
+
+        pytest.param("after tasks missing quotes", ParserError, id="Malformed after tasks"),
     ]
 )
 def test_failure(cond_str, exc):


### PR DESCRIPTION
New syntax:

- ``after tasks 'task 1', 'task 2', 'task 3'``
- ``after any tasks 'task 1', 'task 2', 'task 3'``
- ``after any tasks 'task 1', 'task 2', 'task 3 succeeded'``
- ``after any tasks 'task 1', 'task 2', 'task 3' failed ``
- ``after any tasks 'task 1', 'task 2', 'task 3' finished``
- etc.